### PR TITLE
Feat/self memory

### DIFF
--- a/agentes.py
+++ b/agentes.py
@@ -29,9 +29,7 @@ for nome in sorted(etapas_descricoes.keys()):
 
 lista_etapas.pack(padx=10, pady=10)
 
-chk_valor = tk.BooleanVar()
-chk = tk.Checkbutton(raiz, text="Deseja inserir os obstáculos manualmente?", variable=chk_valor)
-chk.pack(pady=(0, 10))
+chk_valor = None  # Checkbox removido
 
 renderizador_atual: Renderizador | None = None 
 
@@ -58,7 +56,8 @@ def iniciar_simulacao(cls, grid):
 def selecionar_etapa():
     global renderizador_atual
 
-    if renderizador_atual: renderizador_atual.destruir()
+    if renderizador_atual:
+        renderizador_atual.destruir()
 
     selecionado = lista_etapas.get(lista_etapas.curselection())
     cls, descricao = etapas_descricoes[selecionado]
@@ -66,11 +65,8 @@ def selecionar_etapa():
 
     grid = Grid(largura=20, altura=15)
 
-    if chk_valor.get() and cls.permite_adicionar_obstaculos:
-        # if path.exists(NOME_ARQUIVO_OBSTACULOS_SERIALIZADOS):
-        #     try: grid.obstaculos = pickle.load(file=open(NOME_ARQUIVO_OBSTACULOS_SERIALIZADOS, "rb"))
-        #     except Exception as ex: print(ex)
-
+    # Só a etapa 3.2 permite obstáculos manualmente
+    if hasattr(cls, "nome") and cls.nome == "3.2. Agente baseado em objetivos (com obstáculos)":
         raiz_montador_cenario = tk.Toplevel(raiz)
         raiz_montador_cenario.title("Montar cenário")
 
@@ -79,33 +75,25 @@ def selecionar_etapa():
 
         def concluir():
             raiz_montador_cenario.destroy()
-
-            # salvando os obstáculos para não precisar "recolocar" eles depois
-            # with open(NOME_ARQUIVO_OBSTACULOS_SERIALIZADOS, "wb") as arq:
-            #     pickle.dump(grid.obstaculos, arq)
-
             iniciar_simulacao(cls, grid)
 
         txt_instrucoes = tk.Text(
             raiz_montador_cenario,
-            height=6,       
-            width=50,       
-            wrap="word"     
+            height=6,
+            width=50,
+            wrap="word"
         )
-        txt_instrucoes.insert("1.0", 
+        txt_instrucoes.insert("1.0",
             "clique e arraste (bt. esquerdo) para adicionar/remover obstáculos\n"
             "clique duplo para definir o ponto de PARTIDA (azul).\n"
             "shift + clique duplo para definir o ponto de DESTINO (verde)."
         )
-        txt_instrucoes.config(state="disabled") 
+        txt_instrucoes.config(state="disabled")
         txt_instrucoes.pack(pady=10)
 
         btn_concluir = tk.Button(raiz_montador_cenario, text="Concluir", command=concluir)
         btn_concluir.pack(pady=10)
     else:
-        if chk_valor.get() and not cls.permite_adicionar_obstaculos:
-            messagebox.showwarning("Cenário", "Não é possível adicionar obstáculos para esse cenário/etapa")
-
         iniciar_simulacao(cls, grid)
 
 

--- a/etapas/SegundaEtapa.py
+++ b/etapas/SegundaEtapa.py
@@ -1,0 +1,44 @@
+from models import Agente, Estrategia
+
+import random
+
+class SegundaEtapa(Estrategia):
+    nome = "2. Agente reativo baseado em modelo"
+    descricao = "Agente com memória, decisão de movimento baseado nesta. Seu objetivo é visitar o maior número de células, contornando obstáculos e evitando repetições. Grid sem obstáculos."
+
+    mapa = {}
+
+    permite_adicionar_obstaculos = False
+
+    def proximo_passo(self, agente: Agente):
+        direcoes_possiveis = [(1,0), (-1,0), (0,1), (0,-1)]
+        proxima_direcao = random.choice(direcoes_possiveis)
+        x, y = agente.x + proxima_direcao[0], agente.y + proxima_direcao[1]
+        
+        # Célula já visitada
+        if (x, y) in self.mapa: 
+            # Verifica vizinhas
+            vizinhas_possiveis = list(map(lambda dir: (agente.x + dir[0], agente.y + dir[1], dir), set(direcoes_possiveis)))
+            vizinhas_possiveis.remove((x, y, proxima_direcao))
+
+            livres_nao_visitados = [direcao for direcao in vizinhas_possiveis if agente.grid.eh_livre(direcao[0], direcao[1]) and direcao[2] not in self.mapa]
+            # Nesse caso, há células livres, então prioriza essa ao invés da atual. Caso contrário, precisará repetir algum caminho.
+            if livres_nao_visitados:
+                return random.choice(livres_nao_visitados)[2]
+            else:
+                livres = [direcao for direcao in vizinhas_possiveis if agente.grid.eh_livre(direcao[0], direcao[1])]
+
+                if livres: 
+                    direcao_aleatoria = random.choice(livres)
+                    return direcao_aleatoria[2]
+            
+        if not agente.grid.eh_dentro_do_grid(x, y):
+            self.mapa[(x, y)] = False
+        elif not agente.grid.eh_livre(x, y):
+            self.mapa[(x, y)] = False
+        else:
+            self.mapa[(x, y)] = True
+            return proxima_direcao
+
+        # Não se move e permi
+        return (0, 0)

--- a/etapas/TerceiraEtapaComObstaculos.py
+++ b/etapas/TerceiraEtapaComObstaculos.py
@@ -7,7 +7,7 @@ class TerceiraEtapaComObstaculos(Estrategia):
     nome = "3.2. Agente baseado em objetivos (com obstáculos)"
     descricao = "Dadas uma posição de partida (x, y) e uma célula de destino (x1, y1), o agente deve encontrar um caminho entre elas. Grid com obstáculos."
 
-    permite_adicionar_obstaculos = True
+    # permite_adicionar_obstaculos removido por ser redundante
 
     caminho: list[tuple[int, int]] = []
     

--- a/etapas/__init__.py
+++ b/etapas/__init__.py
@@ -1,3 +1,4 @@
 from .PrimeiraEtapa import PrimeiraEtapa
+from .SegundaEtapa import SegundaEtapa
 from .TerceiraEtapaLivre import TerceiraEtapaLivre
 from .TerceiraEtapaComObstaculos import TerceiraEtapaComObstaculos

--- a/models/Agente.py
+++ b/models/Agente.py
@@ -1,6 +1,27 @@
 from models import Estrategia, Grid
 
 class Agente:
+    def explorar_ambiente(self):
+        """
+        Percorre todas as células do grid e retorna um dicionário com a situação de cada célula:
+        - 'livre': célula sem obstáculo
+        - 'obstaculo': célula bloqueada
+        - 'partida': ponto de partida
+        - 'destino': ponto de destino
+        """
+        situacoes = {}
+        for x in range(self.grid.largura):
+            for y in range(self.grid.altura):
+                celula = self.grid.celulas[x][y]
+                if self.grid.ponto_partida_escolhido and (x, y) == (self.grid.ponto_partida_escolhido.x, self.grid.ponto_partida_escolhido.y):
+                    situacoes[(x, y)] = 'partida'
+                elif self.grid.ponto_destino_escolhido and (x, y) == (self.grid.ponto_destino_escolhido.x, self.grid.ponto_destino_escolhido.y):
+                    situacoes[(x, y)] = 'destino'
+                elif celula.eh_obstaculo:
+                    situacoes[(x, y)] = 'obstaculo'
+                else:
+                    situacoes[(x, y)] = 'livre'
+        return situacoes
     def __init__(self, grid: Grid, x, y, estrategia: Estrategia):
         self.grid = grid
         self.x = x


### PR DESCRIPTION
This pull request refactors how obstacle management is handled in the agent simulation UI and introduces the implementation for the second agent stage. The main changes remove the manual obstacle insertion checkbox and related logic, streamline the conditions for obstacle addition, and add the `SegundaEtapa` strategy. Additionally, a utility method for environment exploration is introduced in the `Agente` model.

### UI and Obstacle Management Refactor

* Removed the manual obstacle insertion checkbox (`chk`) from `agentes.py`, simplifying the UI and eliminating redundant logic for obstacle addition.
* Updated the logic in `selecionar_etapa()` to allow manual obstacle placement only for the "3.2. Agente baseado em objetivos (com obstáculos)" stage, removing the previous generic and redundant checks. [[1]](diffhunk://#diff-ceb54de9992f737b0f4bd69901bb86c88247c2a16f63af04a9bae8441f37eafcL61-R69) [[2]](diffhunk://#diff-ceb54de9992f737b0f4bd69901bb86c88247c2a16f63af04a9bae8441f37eafcL106-L108)
* Removed the `permite_adicionar_obstaculos` flag from `TerceiraEtapaComObstaculos`, as it is now handled by stage name instead.

### Agent Strategies and Model Improvements

* Added the implementation for `SegundaEtapa`, representing a memory-based reactive agent that explores the grid and avoids revisiting cells. This strategy is now imported in `etapas/__init__.py`. [[1]](diffhunk://#diff-fd3b44c2e6f51b1a65c8f10ce662746c43452c0d40f6a3dc7c9fc2c15e4c9b36R1-R44) [[2]](diffhunk://#diff-577e20368022e5fc654175356928bedd7eabfee887657d45884b20125c0d2db2R2)
* Introduced the `explorar_ambiente` method to the `Agente` class, allowing agents to scan and classify all grid cells as 'livre', 'obstaculo', 'partida', or 'destino'.